### PR TITLE
add name: key to start_link examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ And using `ExReg` as name registry:
 
 ```elixir
 iex(1)> name = {:name, make_ref()}
-iex(2)> Server.start_link({:via, ExReg, name})
+iex(2)> Server.start_link(name: {:via, ExReg, name})
 iex(3)> Server.ping({:via, ExReg, name})
 :pong
 iex(4)> Server.stop({:via, ExReg, name})

--- a/lib/exreg.ex
+++ b/lib/exreg.ex
@@ -30,7 +30,7 @@ defmodule ExReg do
   And using `ExReg` as name registry:
 
       iex(1)> name = {:name, make_ref()}
-      iex(2)> {:ok, pid} = Server.start_link({:via, ExReg, name})
+      iex(2)> {:ok, pid} = Server.start_link(name: {:via, ExReg, name})
       iex(3)> Server.ping({:via, ExReg, name})
       :pong
       iex(4)> Server.stop({:via, ExReg, name})


### PR DESCRIPTION
I noticed the examples in the readme & code docs wouldn't work for someone (like me!) who was just copying & pasting them in while trying out ExReg
